### PR TITLE
Update workflow to use artifact actions v4

### DIFF
--- a/.github/workflows/pipeline_answer_key.yml
+++ b/.github/workflows/pipeline_answer_key.yml
@@ -28,7 +28,7 @@ jobs:
 
       # checkout the profile, because that's where our profile is!
       - name: PREP - Check out this repository  
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       # double-check that we don't have any serious issues in our profile code
       - name: LINT - Run InSpec Check           

--- a/.github/workflows/pipeline_answer_key.yml
+++ b/.github/workflows/pipeline_answer_key.yml
@@ -28,7 +28,7 @@ jobs:
 
       # checkout the profile, because that's where our profile is!
       - name: PREP - Check out this repository  
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # double-check that we don't have any serious issues in our profile code
       - name: LINT - Run InSpec Check           
@@ -73,7 +73,7 @@ jobs:
 
       # save our results to the pipeline artifacts, even if the InSpec run found failing tests
       - name: VALIDATE - Save Test Result JSON  
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: results/pipeline_run_attested.json
 


### PR DESCRIPTION
Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025