### PR TITLE
Update expected redhat version

### DIFF
--- a/test-lab.sh
+++ b/test-lab.sh
@@ -46,10 +46,10 @@ then
     verificationSuccessful=false
     containersMissing="${containersMissing}The \"nginx\" container is missing.\n"
 fi
-if ! echo "${containersRunning}" | grep --silent --extended-regexp 'redhat8'
+if ! echo "${containersRunning}" | grep --silent --extended-regexp 'redhat9'
 then
     verificationSuccessful=false
-    containersMissing="${containersMissing}The \"redhat8\" container is missing.\n"
+    containersMissing="${containersMissing}The \"redhat9\" container is missing.\n"
 fi
 
 echo -e "${HIGH}* MITRE SAF Version:${RSET} ${statusSaf}"


### PR DESCRIPTION
The docker-compose file sets up a rhel9 instance, but the current test-lab.sh looks for rhel8 (so in a fresh environment, e.g., in the codespace, running build-lab and then test-lab will fail); this changes the test-lab script to look for redhat9 instead of redhat8.